### PR TITLE
Fix: Grant write permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This change adds the `permissions` key to the `deploy.yml` workflow file to grant the `contents: write` permission to the `GITHUB_TOKEN`. This is necessary for the `peaceiris/actions-gh-pages` action to push the built site to the `gh-pages` branch.